### PR TITLE
Improve OptimiseTool and TootleTool usability

### DIFF
--- a/include/MeshMagick.h
+++ b/include/MeshMagick.h
@@ -37,6 +37,9 @@ THE SOFTWARE.
 #include "MmMeshMergeTool.h"
 #include "MmOptimiseTool.h"
 #include "MmRenameTool.h"
+#ifdef MESHMAGICK_USE_TOOTLE
+#	include "MmTootleTool.h"
+#endif
 #include "MmTransformTool.h"
 
 namespace meshmagick
@@ -57,11 +60,19 @@ namespace meshmagick
 
 		InfoTool* getInfoTool();
 		MeshMergeTool* getMeshMergeTool();
+		OptimiseTool* getOptimiseTool();
+#ifdef MESHMAGICK_USE_TOOTLE
+		TootleTool* getTootleTool();
+#endif
 		TransformTool* getTransformTool();
 
 	private:
 		InfoTool* mInfoTool;
 		MeshMergeTool* mMeshMergeTool;
+		OptimiseTool* mOptimiseTool;
+#ifdef MESHMAGICK_USE_TOOTLE
+		TootleTool* mTootleTool;
+#endif
 		TransformTool* mTransformTool;
 
 		ToolManager* mToolManager;

--- a/include/MmOptimiseTool.h
+++ b/include/MmOptimiseTool.h
@@ -36,6 +36,25 @@ THE SOFTWARE.
 
 namespace meshmagick
 {
+	struct UniqueVertex
+	{
+		Ogre::Vector3 position;
+		Ogre::Vector3 normal;
+		Ogre::Vector4 tangent;
+		Ogre::Vector3 binormal;
+		Ogre::Vector3 uv[OGRE_MAX_TEXTURE_COORD_SETS];
+
+		UniqueVertex()
+			: position(Ogre::Vector3::ZERO),
+				normal(Ogre::Vector3::ZERO),
+				tangent(Ogre::Vector4::ZERO),
+				binormal(Ogre::Vector3::ZERO)
+		{
+			memset(uv, 0, sizeof(Ogre::Vector3) * OGRE_MAX_TEXTURE_COORD_SETS);
+		}
+
+	};
+
 	class OptimiseTool : public Tool
 	{
 	public:
@@ -75,24 +94,6 @@ namespace meshmagick
 		typedef std::vector<IndexInfo> IndexRemap;
 		IndexRemap mIndexRemap;
 
-		struct UniqueVertex
-		{
-			Ogre::Vector3 position;
-			Ogre::Vector3 normal;
-			Ogre::Vector4 tangent;
-			Ogre::Vector3 binormal;
-			Ogre::Vector3 uv[OGRE_MAX_TEXTURE_COORD_SETS];
-
-			UniqueVertex()
-				: position(Ogre::Vector3::ZERO),
-				  normal(Ogre::Vector3::ZERO),
-				  tangent(Ogre::Vector4::ZERO),
-				  binormal(Ogre::Vector3::ZERO)
-			{
-				memset(uv, 0, sizeof(Ogre::Vector3) * OGRE_MAX_TEXTURE_COORD_SETS);
-			}
-
-		};
 		struct UniqueVertexLess
 		{
 			float pos_tolerance, norm_tolerance, uv_tolerance;

--- a/include/MmTootleTool.h
+++ b/include/MmTootleTool.h
@@ -53,6 +53,9 @@ namespace meshmagick
 
 		unsigned int getClusters() const { return mClusters; }
 		void setClusters(unsigned int sz) { mClusters = sz; }
+
+		bool getQualityOptimization() const { return mQualityOptimization; }
+		void setQualityOptimization(bool quality) { mQualityOptimization = quality; }
 	protected:
 		virtual void doInvoke(const OptionList& toolOptions,
 			const Ogre::StringVector& inFileNames,
@@ -62,6 +65,7 @@ namespace meshmagick
 		unsigned int mVCacheSize;
 		bool mClockwise;
 		unsigned int mClusters;
+		bool mQualityOptimization;
 		typedef std::vector<Ogre::Vector3> ViewpointList;
 		ViewpointList mViewpointList;
 

--- a/include/MmTootleTool.h
+++ b/include/MmTootleTool.h
@@ -56,6 +56,9 @@ namespace meshmagick
 
 		bool getQualityOptimization() const { return mQualityOptimization; }
 		void setQualityOptimization(bool quality) { mQualityOptimization = quality; }
+
+		bool getVMemoryOptimization() const { return mVMemoryOptimization; }
+		void setVMemoryOptimization(bool vmemory) { mVMemoryOptimization = vmemory; }
 	protected:
 		virtual void doInvoke(const OptionList& toolOptions,
 			const Ogre::StringVector& inFileNames,
@@ -66,6 +69,7 @@ namespace meshmagick
 		bool mClockwise;
 		unsigned int mClusters;
 		bool mQualityOptimization;
+		bool mVMemoryOptimization;
 		typedef std::vector<Ogre::Vector3> ViewpointList;
 		ViewpointList mViewpointList;
 

--- a/src/MeshMagick.cpp
+++ b/src/MeshMagick.cpp
@@ -27,6 +27,9 @@ THE SOFTWARE.
 #include "MmMeshMergeToolFactory.h"
 #include "MmOptimiseToolFactory.h"
 #include "MmRenameToolFactory.h"
+#ifdef MESHMAGICK_USE_TOOTLE
+#	include "MmTootleToolFactory.h"
+#endif
 #include "MmTransformToolFactory.h"
 
 template<> meshmagick::MeshMagick* Ogre::Singleton<meshmagick::MeshMagick>::msSingleton = NULL;
@@ -40,6 +43,10 @@ namespace meshmagick
 		mOgreEnvironment(NULL),
 		mInfoTool(NULL),
 		mMeshMergeTool(NULL),
+		mOptimiseTool(NULL),
+#ifdef MESHMAGICK_USE_TOOTLE
+		mTootleTool(NULL),
+#endif
 		mTransformTool(NULL)
 	{
 		mOgreEnvironment = new OgreEnvironment();
@@ -48,6 +55,10 @@ namespace meshmagick
 		mToolManager = new ToolManager();
 		mToolManager->registerToolFactory(new InfoToolFactory());
 		mToolManager->registerToolFactory(new MeshMergeToolFactory());
+		mToolManager->registerToolFactory(new OptimiseToolFactory());
+#ifdef MESHMAGICK_USE_TOOTLE
+		mToolManager->registerToolFactory(new TootleToolFactory());
+#endif
 		mToolManager->registerToolFactory(new TransformToolFactory());
 	}
     //------------------------------------------------------------------------
@@ -56,6 +67,10 @@ namespace meshmagick
 	{
 		if (mInfoTool != NULL) mToolManager->destroyTool(mInfoTool);
 		if (mMeshMergeTool != NULL) mToolManager->destroyTool(mMeshMergeTool);
+		if (mOptimiseTool != NULL) mToolManager->destroyTool(mOptimiseTool);
+#ifdef MESHMAGICK_USE_TOOTLE
+		if (mTootleTool != NULL) mToolManager->destroyTool(mTootleTool);
+#endif
 		if (mTransformTool != NULL) mToolManager->destroyTool(mTransformTool);
 
 		delete mToolManager;
@@ -80,6 +95,26 @@ namespace meshmagick
 		}
 		return mMeshMergeTool;
 	}
+    //------------------------------------------------------------------------
+	OptimiseTool* MeshMagick::getOptimiseTool()
+	{
+		if (mOptimiseTool == NULL)
+		{
+			mOptimiseTool = static_cast<OptimiseTool*>(mToolManager->createTool("optimise"));
+		}
+		return mOptimiseTool;
+	}
+    //------------------------------------------------------------------------
+#ifdef MESHMAGICK_USE_TOOTLE
+	TootleTool* MeshMagick::getTootleTool()
+	{
+		if (mTootleTool == NULL)
+		{
+			mTootleTool = static_cast<TootleTool*>(mToolManager->createTool("tootle"));
+		}
+		return mTootleTool;
+	}
+#endif
     //------------------------------------------------------------------------
 	TransformTool* MeshMagick::getTransformTool()
 	{

--- a/src/MmOptimiseTool.cpp
+++ b/src/MmOptimiseTool.cpp
@@ -809,8 +809,8 @@ namespace meshmagick
 	}
 	//---------------------------------------------------------------------
 	bool OptimiseTool::UniqueVertexLess::operator ()(
-		const OptimiseTool::UniqueVertex &a,
-		const OptimiseTool::UniqueVertex &b) const
+		const UniqueVertex &a,
+		const UniqueVertex &b) const
 	{
 		if (!equals(a.position, b.position, pos_tolerance))
 		{

--- a/src/MmTootleTool.cpp
+++ b/src/MmTootleTool.cpp
@@ -90,7 +90,7 @@ namespace meshmagick
 		// Lock all the buffers first
 		typedef std::vector<char*> BufferLocks;
 		BufferLocks bufferLocks;
-		const v1::VertexBufferBinding::VertexBufferBindingMap& bindings =
+		const auto& bindings =
 			vertexBufferBinding->getBindings();
 		v1::VertexBufferBinding::VertexBufferBindingMap::const_iterator bindi;
 		bufferLocks.resize(vertexBufferBinding->getLastBoundIndex()+1);
@@ -103,7 +103,7 @@ namespace meshmagick
 		for(size_t i=0;i<numvertices;i++)
 		{
 			UniqueVertex uniqueVertex;
-			const v1::VertexDeclaration::VertexElementList& elemList =
+			const auto& elemList =
 				vertexDeclaration->getElements();
 			v1::VertexDeclaration::VertexElementList::const_iterator elemi;
 			unsigned short uvSets = 0;
@@ -222,7 +222,7 @@ namespace meshmagick
 		// Lock all the buffers first
 		typedef std::vector<char*> BufferLocks;
 		BufferLocks bufferLocks;
-		const v1::VertexBufferBinding::VertexBufferBindingMap& bindings =
+		const auto& bindings =
 			vertexBufferBinding->getBindings();
 		v1::VertexBufferBinding::VertexBufferBindingMap::const_iterator bindi;
 		bufferLocks.resize(vertexBufferBinding->getLastBoundIndex()+1);
@@ -235,7 +235,7 @@ namespace meshmagick
 		for(size_t i=0;i<numvertices;i++)
 		{
 			unsigned int nVID = verticesRemap[i];
-			const v1::VertexDeclaration::VertexElementList& elemList =
+			const auto& elemList =
 				vertexDeclaration->getElements();
 			v1::VertexDeclaration::VertexElementList::const_iterator elemi;
 			unsigned short uvSets = 0;
@@ -342,7 +342,7 @@ namespace meshmagick
 		v1::Mesh::VertexBoneAssignmentList newList;
 		for (; bit != eit; ++bit)
 		{
-			v1::VertexBoneAssignment ass = bit->second;
+			auto ass = bit->second;
 			ass.vertexIndex = verticesRemap[ass.vertexIndex];
 
 			newList.insert(v1::Mesh::VertexBoneAssignmentList::value_type(


### PR DESCRIPTION
- Expose OptimiseTool and TootleTool API so they can be used as a library too
- Make AMD Tootle algorithm from SIGGRAPH 2007 the default as recommended by their doc (see: https://github.com/GPUOpen-Archive/amd_tootle/blob/master/src/TootleSample/Tootle.cpp#L931)
- Optimize vertex prefetch cache (see: https://github.com/GPUOpen-Archive/amd_tootle/blame/master/README.md#L13)